### PR TITLE
Ipfixprobe

### DIFF
--- a/net/nemea-modules/Config.in
+++ b/net/nemea-modules/Config.in
@@ -1,6 +1,5 @@
 menu "Configuration"
-	depends on PACKAGE_nemea-flow_meter
-	depends on PACKAGE_nemea-ipfixprobe
+	depends on PACKAGE_nemea-flow_meter || PACKAGE_nemea-ipfixprobe
 
    config NEMEA_FLOW_CACHE_SIZE
       int "Flow cache size"

--- a/net/nemea-modules/Config.in
+++ b/net/nemea-modules/Config.in
@@ -1,5 +1,6 @@
 menu "Configuration"
 	depends on PACKAGE_nemea-flow_meter
+	depends on PACKAGE_nemea-ipfixprobe
 
    config NEMEA_FLOW_CACHE_SIZE
       int "Flow cache size"

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -61,6 +61,10 @@ define Package/nemea-ipfixprobe
 	DEPENDS= +libpcap +libstdcpp
 endef
 
+define Package/nemea-ipfixprobe/config
+	select PACKAGE_nemea-flow_meter
+endef
+
 define Package/conffiles/nemea-ipfixprobe
 /etc/config/ipfixprobe
 endef
@@ -89,11 +93,6 @@ endef
 
 define Package/nemea-flow_meter/config
 	source "$(SOURCE)/Config.in"
-endef
-
-define Package/nemea-ipfixprobe/config
-	source "$(SOURCE)/Config.in"
-	source "$(SOURCE)/../../libs/nemea-framework/Config.in"
 endef
 
 TARGET_CFLAGS += \

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -91,6 +91,11 @@ define Package/nemea-flow_meter/config
 	source "$(SOURCE)/Config.in"
 endef
 
+define Package/nemea-ipfixprobe/config
+	source "$(SOURCE)/Config.in"
+	source "$(SOURCE)/../../libs/nemea-framework/Config.in"
+endef
+
 TARGET_CFLAGS += \
 	-ffunction-sections \
 	-fdata-sections

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -50,11 +50,21 @@ define Package/nemea-flow_meter
 	TITLE+=flow_meter
 	DEPENDS+= +libpcap +libstdcpp
 endef
+
+define Package/conffiles/nemea-flow_meter
+/etc/config/flow_meter
+endef
+
 define Package/nemea-ipfixprobe
 	$(call Package/nemea-modules/Default)
 	TITLE+=ipfixprobe
 	DEPENDS= +libpcap +libstdcpp
 endef
+
+define Package/conffiles/nemea-ipfixprobe
+/etc/config/ipfixprobe
+endef
+
 define Package/nemea-logreplay
 	$(call Package/nemea-modules/Default)
 	TITLE+=logreplay

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=nemea-modules
-PKG_REV:=03ea807
+PKG_REV:=bcaa607
 PKG_VERSION:=2.10.1
 PKG_RELEASE:=1
 

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -9,7 +9,7 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=nemea-modules
-PKG_REV:=de3c61adbbbc2492cd1759956bc945d9f728a5ac
+PKG_REV:=eb7d0bd
 PKG_VERSION:=$(PKG_REV)
 PKG_RELEASE:=1
 
@@ -49,6 +49,11 @@ define Package/nemea-flow_meter
 	$(call Package/nemea-modules/Default)
 	TITLE+=flow_meter
 	DEPENDS+= +libpcap +libstdcpp
+endef
+define Package/nemea-ipfixprobe
+	$(call Package/nemea-modules/Default)
+	TITLE+=ipfixprobe
+	DEPENDS= +libpcap +libstdcpp
 endef
 define Package/nemea-logreplay
 	$(call Package/nemea-modules/Default)
@@ -110,6 +115,19 @@ define Package/nemea-flow_meter/install
 	$(INSTALL_DATA) ./files/config/flow_meter $(1)/etc/config/
 endef
 
+define Package/nemea-ipfixprobe/install
+	$(INSTALL_DIR) $(1)/usr/bin/nemea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/ipfixprobe $(1)/usr/bin/nemea/
+
+	$(INSTALL_DIR) $(1)/etc/init.d
+	$(INSTALL_BIN) ./files/init.d/flow_meter $(1)/etc/init.d/ipfixprobe
+
+	$(INSTALL_DIR) $(1)/etc/config
+	$(INSTALL_DATA) ./files/config/flow_meter $(1)/etc/config/ipfixprobe
+	$(SED) "s,flow_meter,ipfixprobe,g" $(1)/etc/init.d/ipfixprobe $(1)/etc/config/ipfixprobe
+	$(SED) "s,option ipfix_enable 0,option ipfix_enable 1,;s,option ipfix_udp 0,option ipfix_udp 1," $(1)/etc/config/ipfixprobe
+endef
+
 define Package/nemea-flowcounter/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/flowcounter $(1)/usr/bin/nemea/
@@ -132,6 +150,7 @@ define Package/nemea-logger/install
 endef
 
 $(eval $(call BuildPackage,nemea-flow_meter))
+$(eval $(call BuildPackage,nemea-ipfixprobe))
 $(eval $(call BuildPackage,nemea-flowcounter))
 $(eval $(call BuildPackage,nemea-logreplay))
 $(eval $(call BuildPackage,nemea-traffic_repeater))

--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -9,8 +9,8 @@ include $(TOPDIR)/rules.mk
 
 
 PKG_NAME:=nemea-modules
-PKG_REV:=eb7d0bd
-PKG_VERSION:=$(PKG_REV)
+PKG_REV:=03ea807
+PKG_VERSION:=2.10.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git

--- a/net/nemea-modules/patches/001-removemodules.patch
+++ b/net/nemea-modules/patches/001-removemodules.patch
@@ -1,11 +1,12 @@
 diff --git a/Makefile.am b/Makefile.am
-index f019dcd..2ac92df 100644
+index 2f71543..2ac92df 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -1,44 +1,13 @@
+@@ -1,61 +1,13 @@
  ACLOCAL_AMFLAGS = -I m4
  
--SUBDIRS=anonymizer \
+-SUBDIRS=aggregator \
+-anonymizer \
 -debug_sender \
 -device_classifier \
 -email_reporter \
@@ -21,40 +22,82 @@ index f019dcd..2ac92df 100644
 -merger \
 -mux \
 -demux \
+-natpair \
 -proto_traffic \
+-pdns_exporter \
 -report2idea \
 -topn \
 -traffic_repeater \
 -unirec2json \
 -endiverter
 -
--EXTRA_DIST = AUTHORS COPYING ChangeLog INSTALL NEWS README.md nfreader
+-EXTRA_DIST = AUTHORS COPYING ChangeLog INSTALL NEWS README.md nfreader \
+-	debian/README.Debian \
+-	debian/changelog \
+-	debian/compat \
+-	debian/control \
+-	debian/copyright \
+-	debian/nemea-modules-dev.install \
+-	debian/nemea-modules.install \
+-	debian/patches \
+-	debian/rules \
+-	debian/source \
+-	debian/watch
 -
 -if HAVE_LIBNF
 -SUBDIRS += nfreader
 -SUBDIRS += nfwriter
 -endif
--
++topn
+ 
 -if HAVE_BISON
 -SUBDIRS += unirecfilter
 -if HAVE_OPENSSL
--SUBDIRS += aggregator
+-SUBDIRS += scalar-aggregator
 -endif
 -endif
 -
 -if HAVE_LIBPCAP
 -SUBDIRS += flow_meter
 -endif
-+topn
- 
+-
+-if HAVE_LIBCURL
+-SUBDIRS += blooming_history
+-endif
 +EXTRA_DIST = AUTHORS COPYING ChangeLog INSTALL NEWS README.md
  
  RPMDIR = RPMBUILD
  
+@@ -77,16 +29,3 @@ endif
+ 
+ rpm-clean:
+ 	rm -rf $(RPMDIR)
+-
+-if MAKE_DEB
+-.PHONY: deb
+-deb:
+-	make distdir && cd nemea-modules-@VERSION@ && debuild -i -us -uc -b
+-else
+-endif
+-
+-deb-clean:
+-	rm -rf nemea-modules_*.build* nemea-modules_*.changes nemea-modules*.deb nemea-modules_*.orig.tar.gz nemea-modules-*.tar.gz nemea-modules-@VERSION@
+-
+-clean-local: rpm-clean deb-clean
+-
 diff --git a/configure.ac b/configure.ac
-index 2f09ac2..e9f2415 100644
+index 7e6f7ab..e1c0cfa 100644
 --- a/configure.ac
 +++ b/configure.ac
+@@ -2,7 +2,7 @@
+ # Process this file with autoconf to produce a configure script.
+ 
+ AC_PREREQ([2.63])
+-AC_INIT([nemea-modules], [2.8.2], [nemea@cesnet.cz])
++AC_INIT([nemea-modules], [2.6.1], [nemea@cesnet.cz])
+ AC_CONFIG_SRCDIR([flowcounter/flowcounter.c])
+ AC_CONFIG_HEADERS([config.h])
+ RELEASE=1
 @@ -43,11 +43,6 @@ AC_SUBST(BINDIR)
  bashcompldir=${sysconfdir}/bash_completion.d
  AC_SUBST(bashcompldir)
@@ -67,17 +110,56 @@ index 2f09ac2..e9f2415 100644
  RPM_REQUIRES=
  RPM_BUILDREQ=
  
-@@ -80,9 +75,6 @@ esac], [repobuild=false])
+@@ -64,7 +59,6 @@ AC_CHECK_PROG(PYTHON, python, python, [""])
+ AC_SUBST(PYTHON)
+ # Check for rpmbuild
+ AC_CHECK_PROG(RPMBUILD, rpmbuild, rpmbuild, [""])
+-AC_CHECK_PROG(DEBUILD, debuild, debuild, [""])
+ AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"
+     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
+     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
+@@ -81,15 +75,13 @@ esac], [repobuild=false])
  
  AX_C_BIGENDIAN_CROSS
  
 -AX_OPENMP([], [AC_MSG_ERROR([OpenMP was not found. Some modules need it (e.g. merger)])])
 -AC_SUBST(OPENMP_CFLAGS)
 -
+ backup_libs=${LIBS}
  AX_LIBTRAP_CHECK
  AX_UNIREC_CHECK
  AX_NEMEACOMMON_CHECK
-@@ -117,36 +109,6 @@ AC_ARG_WITH([flowcachestats],
+ LIBS=${backup_libs}
+ 
++
+ AC_ARG_WITH([openssl],
+         [AS_HELP_STRING([--without-openssl], [Force to disable openssl])],
+         [if test x$withval = xyes; then
+@@ -104,22 +96,7 @@ if test x$have_openssl = xyes; then
+   RPM_BUILDREQ+=" openssl-devel"
+ else
+   AC_DEFINE([HAVE_OPENSSL], [0], [Define to 1 if the openssl is available])
+-fi
+-
+-AC_ARG_WITH([libcurl],
+-        [AS_HELP_STRING([--without-libcurl], [Force to disable libcurl])],
+-        [if test x$withval = xyes; then
+-        PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl="yes"], [have_libcurl="no"])
+-        fi],
+-        [PKG_CHECK_MODULES([libcurl], [libcurl], [have_libcurl="yes"], [have_libcurl="no"])])
+-
+-AM_CONDITIONAL([HAVE_LIBCURL], [test x$have_libcurl = xyes])
+-if test x$have_libcurl = xyes; then
+-  AC_DEFINE([HAVE_LIBCURL], [1], [Define to 1 if the libcurl is available])
+-  RPM_REQUIRES+=" libcurl"
+-  RPM_BUILDREQ+=" libcurl-devel"
+-else
+-  AC_DEFINE([HAVE_LIBCURL], [0], [Define to 1 if the libcurl is available])
++  AC_MSG_WARN([openssl not found. The aggregator module will not be compiled.])
+ fi
+ 
+ AC_ARG_WITH([flowcachesize],
+@@ -135,36 +112,6 @@ AC_ARG_WITH([flowcachestats],
  	]
  )
  
@@ -114,7 +196,7 @@ index 2f09ac2..e9f2415 100644
  AC_CHECK_HEADER(pcap.h,
          AC_CHECK_LIB(pcap, pcap_open_live, [libpcap=yes], AC_MSG_WARN([libpcap not found. The flow_meter module will not be compiled.])), AC_MSG_WARN([pcap.h not found. The flow_meter module will not be compiled.]))
  
-@@ -157,7 +119,7 @@ RPM_BUILDREQ+=" libpcap-devel"
+@@ -175,7 +122,7 @@ RPM_BUILDREQ+=" libpcap-devel"
  fi
  
  # Checks for header files.
@@ -123,12 +205,19 @@ index 2f09ac2..e9f2415 100644
  
  # Checks for typedefs, structures, and compiler characteristics.
  AC_HEADER_STDBOOL
-@@ -198,57 +160,14 @@ AM_CONDITIONAL(MAKE_RPMS, test x$RPMBUILD != x)
+@@ -212,67 +159,18 @@ RPM_RELEASE=1
+ AC_SUBST(RPM_RELEASE)
+ AM_CONDITIONAL(MAKE_RPMS, test x$RPMBUILD != x)
+ 
+-AM_CONDITIONAL(MAKE_DEB, test x$DEBUILD != x)
+-
+ #DX_INIT_DOXYGEN([nemea-cpd], [Doxyfile], [doc])
  
  # list of all *.in (and Makefile.am) files to process by configure script
  AC_CONFIG_FILES([Makefile
 -                 aggregator/Makefile
 -                 anonymizer/Makefile
+-                 blooming_history/Makefile
 -                 debug_sender/Makefile
 -                 device_classifier/Makefile
 -                 device_classifier/libsvm/tools/train.sh
@@ -154,8 +243,10 @@ index 2f09ac2..e9f2415 100644
 -                 merger/Makefile
 -                 mux/Makefile
 -                 demux/Makefile
+-                 natpair/Makefile
 -                 nemea-modules.spec
 -                 nfreader/Makefile
+-                 pdns_exporter/Makefile
 -                 proto_traffic/Makefile
 -                 proto_traffic/munin/Makefile
 -                 report2idea/Makefile
@@ -165,12 +256,13 @@ index 2f09ac2..e9f2415 100644
 -                 report2idea/dnstunnel/Makefile
 -                 report2idea/haddrscan/Makefile
 -                 report2idea/hoststats/Makefile
--                 report2idea/ipblacklist/Makefile
+-                 report2idea/blacklist/Makefile
 -                 report2idea/minerdetector/Makefile
 -                 report2idea/sipbruteforce/Makefile
 -                 report2idea/venom/Makefile
 -                 report2idea/voipfraud/Makefile
 -                 report2idea/vportscan/Makefile
+-                 scalar-aggregator/Makefile
                   topn/Makefile
                   traffic_repeater/Makefile
 -                 unirec2json/Makefile

--- a/net/nemea-modules/patches/001-removemodules.patch
+++ b/net/nemea-modules/patches/001-removemodules.patch
@@ -1,8 +1,8 @@
 diff --git a/Makefile.am b/Makefile.am
-index 2f71543..2ac92df 100644
+index 0895633..36d5bd6 100644
 --- a/Makefile.am
 +++ b/Makefile.am
-@@ -1,61 +1,13 @@
+@@ -1,63 +1,13 @@
  ACLOCAL_AMFLAGS = -I m4
  
 -SUBDIRS=aggregator \
@@ -23,9 +23,11 @@ index 2f71543..2ac92df 100644
 -mux \
 -demux \
 -natpair \
+-prefix_tags \
 -proto_traffic \
 -pdns_exporter \
 -report2idea \
+-resolver \
 -topn \
 -traffic_repeater \
 -unirec2json \
@@ -43,13 +45,13 @@ index 2f71543..2ac92df 100644
 -	debian/rules \
 -	debian/source \
 -	debian/watch
--
++topn
+ 
 -if HAVE_LIBNF
 -SUBDIRS += nfreader
 -SUBDIRS += nfwriter
 -endif
-+topn
- 
+-
 -if HAVE_BISON
 -SUBDIRS += unirecfilter
 -if HAVE_OPENSSL
@@ -62,42 +64,16 @@ index 2f71543..2ac92df 100644
 -endif
 -
 -if HAVE_LIBCURL
--SUBDIRS += blooming_history
+-SUBDIRS += bloom_history
 -endif
 +EXTRA_DIST = AUTHORS COPYING ChangeLog INSTALL NEWS README.md
  
  RPMDIR = RPMBUILD
  
-@@ -77,16 +29,3 @@ endif
- 
- rpm-clean:
- 	rm -rf $(RPMDIR)
--
--if MAKE_DEB
--.PHONY: deb
--deb:
--	make distdir && cd nemea-modules-@VERSION@ && debuild -i -us -uc -b
--else
--endif
--
--deb-clean:
--	rm -rf nemea-modules_*.build* nemea-modules_*.changes nemea-modules*.deb nemea-modules_*.orig.tar.gz nemea-modules-*.tar.gz nemea-modules-@VERSION@
--
--clean-local: rpm-clean deb-clean
--
 diff --git a/configure.ac b/configure.ac
-index 7e6f7ab..e1c0cfa 100644
+index 92df371..652e5db 100644
 --- a/configure.ac
 +++ b/configure.ac
-@@ -2,7 +2,7 @@
- # Process this file with autoconf to produce a configure script.
- 
- AC_PREREQ([2.63])
--AC_INIT([nemea-modules], [2.8.2], [nemea@cesnet.cz])
-+AC_INIT([nemea-modules], [2.6.1], [nemea@cesnet.cz])
- AC_CONFIG_SRCDIR([flowcounter/flowcounter.c])
- AC_CONFIG_HEADERS([config.h])
- RELEASE=1
 @@ -43,11 +43,6 @@ AC_SUBST(BINDIR)
  bashcompldir=${sysconfdir}/bash_completion.d
  AC_SUBST(bashcompldir)
@@ -110,15 +86,7 @@ index 7e6f7ab..e1c0cfa 100644
  RPM_REQUIRES=
  RPM_BUILDREQ=
  
-@@ -64,7 +59,6 @@ AC_CHECK_PROG(PYTHON, python, python, [""])
- AC_SUBST(PYTHON)
- # Check for rpmbuild
- AC_CHECK_PROG(RPMBUILD, rpmbuild, rpmbuild, [""])
--AC_CHECK_PROG(DEBUILD, debuild, debuild, [""])
- AX_PTHREAD([LIBS="$PTHREAD_LIBS $LIBS"
-     CFLAGS="$CFLAGS $PTHREAD_CFLAGS"
-     CXXFLAGS="$CXXFLAGS $PTHREAD_CFLAGS"
-@@ -81,15 +75,13 @@ esac], [repobuild=false])
+@@ -81,9 +76,6 @@ esac], [repobuild=false])
  
  AX_C_BIGENDIAN_CROSS
  
@@ -128,19 +96,10 @@ index 7e6f7ab..e1c0cfa 100644
  backup_libs=${LIBS}
  AX_LIBTRAP_CHECK
  AX_UNIREC_CHECK
- AX_NEMEACOMMON_CHECK
- LIBS=${backup_libs}
- 
-+
- AC_ARG_WITH([openssl],
-         [AS_HELP_STRING([--without-openssl], [Force to disable openssl])],
-         [if test x$withval = xyes; then
-@@ -104,22 +96,7 @@ if test x$have_openssl = xyes; then
-   RPM_BUILDREQ+=" openssl-devel"
- else
+@@ -106,22 +98,6 @@ else
    AC_DEFINE([HAVE_OPENSSL], [0], [Define to 1 if the openssl is available])
--fi
--
+ fi
+ 
 -AC_ARG_WITH([libcurl],
 -        [AS_HELP_STRING([--without-libcurl], [Force to disable libcurl])],
 -        [if test x$withval = xyes; then
@@ -155,11 +114,12 @@ index 7e6f7ab..e1c0cfa 100644
 -  RPM_BUILDREQ+=" libcurl-devel"
 -else
 -  AC_DEFINE([HAVE_LIBCURL], [0], [Define to 1 if the libcurl is available])
-+  AC_MSG_WARN([openssl not found. The aggregator module will not be compiled.])
- fi
- 
+-fi
+-
  AC_ARG_WITH([flowcachesize],
-@@ -135,36 +112,6 @@ AC_ARG_WITH([flowcachestats],
+ 	AC_HELP_STRING([--with-flowcachesize=NUMBER],[Set default size of flow cache for flow_meter module in number of flow records.]),
+ 	[
+@@ -135,36 +111,6 @@ AC_ARG_WITH([flowcachestats],
  	]
  )
  
@@ -196,7 +156,7 @@ index 7e6f7ab..e1c0cfa 100644
  AC_CHECK_HEADER(pcap.h,
          AC_CHECK_LIB(pcap, pcap_open_live, [libpcap=yes], AC_MSG_WARN([libpcap not found. The flow_meter module will not be compiled.])), AC_MSG_WARN([pcap.h not found. The flow_meter module will not be compiled.]))
  
-@@ -175,7 +122,7 @@ RPM_BUILDREQ+=" libpcap-devel"
+@@ -175,7 +121,7 @@ RPM_BUILDREQ+=" libpcap-devel"
  fi
  
  # Checks for header files.
@@ -205,19 +165,13 @@ index 7e6f7ab..e1c0cfa 100644
  
  # Checks for typedefs, structures, and compiler characteristics.
  AC_HEADER_STDBOOL
-@@ -212,67 +159,18 @@ RPM_RELEASE=1
- AC_SUBST(RPM_RELEASE)
- AM_CONDITIONAL(MAKE_RPMS, test x$RPMBUILD != x)
- 
--AM_CONDITIONAL(MAKE_DEB, test x$DEBUILD != x)
--
- #DX_INIT_DOXYGEN([nemea-cpd], [Doxyfile], [doc])
+@@ -218,63 +164,14 @@ AM_CONDITIONAL(MAKE_DEB, test x$DEBUILD != x)
  
  # list of all *.in (and Makefile.am) files to process by configure script
  AC_CONFIG_FILES([Makefile
 -                 aggregator/Makefile
 -                 anonymizer/Makefile
--                 blooming_history/Makefile
+-                 bloom_history/Makefile
 -                 debug_sender/Makefile
 -                 device_classifier/Makefile
 -                 device_classifier/libsvm/tools/train.sh
@@ -229,7 +183,7 @@ index 7e6f7ab..e1c0cfa 100644
 -                 email_reporter/Makefile
                   flowcounter/Makefile
                   flow_meter/Makefile
--                 flow_meter/flow_meter.bash
+                  flow_meter/flow_meter.bash
                   flow_meter/tests/Makefile
 -                 ipv6stats/Makefile
 -                 json_dump/Makefile
@@ -237,7 +191,6 @@ index 7e6f7ab..e1c0cfa 100644
 -                 link_traffic/Makefile
 -                 link_traffic/munin/Makefile
 -                 link_traffic/link_traff2json.py
-+                 flow_meter/flow_meter.bash
                   logger/Makefile
                   logreplay/Makefile
 -                 merger/Makefile
@@ -247,6 +200,7 @@ index 7e6f7ab..e1c0cfa 100644
 -                 nemea-modules.spec
 -                 nfreader/Makefile
 -                 pdns_exporter/Makefile
+-                 prefix_tags/Makefile
 -                 proto_traffic/Makefile
 -                 proto_traffic/munin/Makefile
 -                 report2idea/Makefile
@@ -262,6 +216,7 @@ index 7e6f7ab..e1c0cfa 100644
 -                 report2idea/venom/Makefile
 -                 report2idea/voipfraud/Makefile
 -                 report2idea/vportscan/Makefile
+-                 resolver/Makefile
 -                 scalar-aggregator/Makefile
                   topn/Makefile
                   traffic_repeater/Makefile


### PR DESCRIPTION
This patch creates new package with ipfixprobe module. ipfixprobe does not require nemea-framework so it consumes low space to export flow records in IPFIX format.
Configuration files are marked as conffiles now.