### PR TITLE
supervisorl: status: workaround for older turris omnia

### DIFF
--- a/net/nemea-modules/files/init.d/nemea-supervisorl
+++ b/net/nemea-modules/files/init.d/nemea-supervisorl
@@ -87,10 +87,16 @@ module_status()
    local config="$1"
    local custom="$2"
    config_get ENABLED       "$config"  enabled           ""
+   config_get MODULEPATH    "$config"  path              ""
+   config_get MODULEPARAMS  "$config"  params            ""
 
    echo -n "$config "
    [ "$ENABLED" = 1 ] && echo -n enabled || echo -n disabled
    pid="`cat "${PIDFILE_PREFIX}${config}${PIDFILE_SUFFIX}" 2>/dev/null`"
+   if [ -z "$pid" ]; then
+      # if pidfile does not exist, try to find the process with pgrep:
+      pid="`pgrep -f "^${MODULEPATH} ${MODULEPARAMS}$" 2>/dev/null`"
+   fi
    if [ -n "$pid" -a -d /proc/"$pid" ]; then
       echo " running"
    else


### PR DESCRIPTION
procd doesn't know pidfile option, so the files are not created when modules
are starting.  This workaround uses `path` and `params` given in config and
searches for the module using pgrep as a fallback solution.  The patch must be
tested on a real omnia device.