### PR TITLE
Makefile polishing

### DIFF
--- a/net/gateway/beeeon-gateway/Makefile
+++ b/net/gateway/beeeon-gateway/Makefile
@@ -10,21 +10,17 @@
 include $(TOPDIR)/rules.mk
 
 PKG_NAME:=beeeon-gateway
-PKG_REV:=7328b4377efcba98d1fef25372f2d2d6a7e685f0
-
 PKG_VERSION:=v2019.7.1
 PKG_RELEASE:=1
-INIT_SCRIPT_NAME:=$(PKG_NAME)
-
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_URL:=https://github.com/BeeeOn/gateway.git
-PKG_SOURCE_VERSION:=$(PKG_REV)
+PKG_SOURCE_VERSION:=7328b4377efcba98d1fef25372f2d2d6a7e685f0
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
 
-BUILD_DIR:=$(TOPDIR)/build_dir/turris
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION).tar.gz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-PKG_BUILD_DIR:=${BUILD_DIR}/${PKG_SOURCE_SUBDIR}
+PKG_MAINTAINER:=Jan Viktorin <iviktorin@fit.vutbr.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
 PKG_BUILD_PARALLEL:=1
 CMAKE_INSTALL:=1
@@ -71,19 +67,18 @@ PKG_BUILD_DEPENDS += BEEEON_GATEWAY_MQTT_EXPORTER:mosquitto
 PKG_BUILD_DEPENDS += BEEEON_GATEWAY_ZWAVE:openzwave
 
 define Package/beeeon-gateway
-	TITLE:=BeeeOn Gateway
-	SECTION:=cesnet
-	CATEGORY:=CESNET
-	DEPENDS:=+poco-all +libmosquittopp
-	MAINTAINER:=Jan Viktorin <iviktorin@fit.vutbr.cz>
-
-	DEPENDS += +BEEEON_GATEWAY_ZWAVE:libopenzwave
-	DEPENDS += +BEEEON_GATEWAY_ZWAVE:openzwave-config
-	DEPENDS += +bluez-daemon +bluez-libs +glib2 +libmosquittopp +nemea-framework +libpcap
+  SECTION:=utils
+  CATEGORY:=Utilities
+  TITLE:=BeeeOn Gateway
+  URL:=https://beeeon.github.io/gateway/
+  DEPENDS:=+poco-all +libmosquittopp
+  DEPENDS += +BEEEON_GATEWAY_ZWAVE:libopenzwave
+  DEPENDS += +BEEEON_GATEWAY_ZWAVE:openzwave-config
+  DEPENDS += +bluez-daemon +bluez-libs +glib2 +libmosquittopp +nemea-framework +libpcap
 endef
 
 define Package/beeeon-gateway/description
- Main application for BeeeOn Gateway.
+  Main application for BeeeOn Gateway.
 endef
 
 BEEEON_GATEWAY_MODULE_ENABLE += belkinwemo \

--- a/net/gateway/poco-all/Makefile
+++ b/net/gateway/poco-all/Makefile
@@ -26,8 +26,8 @@ PKG_INSTALL:=1
 include $(INCLUDE_DIR)/package.mk
 
 define Package/poco-all
-  SECTION:=cesnet
-  CATEGORY:=CESNET
+  SECTION:=libs
+  CATEGORY:=Libraries
   TITLE:=Poco C++ libraries
   URL:=http://www.pocoproject.org/
   DEPENDS:=+libstdcpp +libpthread +librt +libopenssl

--- a/net/nemea-siot/Makefile
+++ b/net/nemea-siot/Makefile
@@ -1,36 +1,19 @@
-#
-# Copyright (C) 2006-2013 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
-
 PKG_NAME:=nemea-siot
-PKG_REV:=dd3b9a73af68aa54857b38ed18320c5078f08523
-
 PKG_VERSION:=19-08.1
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=nemea-siot-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/CESNET/nemea-siot
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_FIXUP:=autoreconf
-
-
-PKG_LICENSE:=GPLv2
-PKG_LICENSE_FILES:=COPYING
+PKG_SOURCE_URL:=https://github.com/CESNET/nemea-siot.git
+PKG_SOURCE_VERSION:=dd3b9a73af68aa54857b38ed18320c5078f08523
+PKG_SOURCE:=$(PKG_NAME)-$(PKG_SOURCE_VERSION).tar.gz
 
 PKG_MAINTAINER:=Tomas Cejka <cejkat@cesnet.cz>
+PKG_LICENSE:=BSD-3-Clause
+PKG_LICENSE_FILES:=LICENSE
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -39,38 +22,42 @@ include $(INCLUDE_DIR)/package.mk
 define Package/nemea-siot/Default
   SECTION:=net
   CATEGORY:=Network
-  SUBMENU:=NEMEA-SIoT
-  DEPENDS:=+nemea-framework +libpthread +librt
+  SUBMENU:=NEMEA
   TITLE:=NEMEA SIoT modules
   URL:=https://github.com/CESNET/nemea-siot
-  MENU:=1
+  DEPENDS:=+nemea-framework +libpthread +librt
 endef
 
-define Package/nemea-ble_pairing
-	$(call Package/nemea-siot/Default)
-	TITLE+=BLE pairing detector
-	DEPENDS+= +libstdcpp +bluez-libs
+define Package/siot-ble-pairing
+  $(call Package/nemea-siot/Default)
+  TITLE:=BLE pairing detector
+  DEPENDS+= +libstdcpp +bluez-libs
 endef
-define Package/nemea-ble_hci_collector
-	$(call Package/nemea-siot/Default)
-	TITLE+=BLE HCI collector
-	DEPENDS+= +libstdcpp +bluez-libs
+
+define Package/siot-hci-collector
+  $(call Package/nemea-siot/Default)
+  TITLE:=BLE HCI collector
+  DEPENDS+= +libstdcpp +bluez-libs
 endef
-define Package/nemea-lora-airtime
-	$(call Package/nemea-siot/Default)
-	TITLE+=LoRaWAN Airtime regulations
+
+define Package/siot-lora-airtime
+  $(call Package/nemea-siot/Default)
+  TITLE:=LoRaWAN Airtime regulations
 endef
-define Package/nemea-lora-distance
-	$(call Package/nemea-siot/Default)
-	TITLE+=LoRaWAN detection of distance change
+
+define Package/siot-lora-distance
+  $(call Package/nemea-siot/Default)
+  TITLE:=LoRaWAN detection of distance change
 endef
-define Package/nemea-lora-replay-abp
-	$(call Package/nemea-siot/Default)
-	TITLE+=LoRaWAN Replay attack ABP detection
+
+define Package/siot-lora-replay
+  $(call Package/nemea-siot/Default)
+  TITLE:=LoRaWAN Replay attack ABP detection
 endef
-define Package/nemea-wsn-detector
-	$(call Package/nemea-siot/Default)
-	TITLE+=Wireless Sensor Network Detector (based on time series)
+
+define Package/siot-wsn-anomaly
+  $(call Package/nemea-siot/Default)
+  TITLE:=Wireless Sensor Network Detector (based on time series)
 endef
 
 TARGET_CFLAGS += \
@@ -95,27 +82,32 @@ define Build/Configure
 	$(call Build/Configure/Default)
 endef
 
-define Package/nemea-ble_pairing/install
+define Package/siot-ble-pairing/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-ble-pairing $(1)/usr/bin/nemea/
 endef
-define Package/nemea-ble_hci_collector/install
+
+define Package/siot-hci-collector/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-hci-collector $(1)/usr/bin/nemea/
 endef
-define Package/nemea-lora-airtime/install
+
+define Package/siot-lora-airtime/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-lora-airtime $(1)/usr/bin/nemea/
 endef
-define Package/nemea-lora-distance/install
+
+define Package/siot-lora-distance/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-lora-distance $(1)/usr/bin/nemea/
 endef
-define Package/nemea-lora-replay-abp/install
+
+define Package/siot-lora-replay/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-lora-replay $(1)/usr/bin/nemea/
 endef
-define Package/nemea-wsn-detector/install
+
+define Package/siot-wsn-anomaly/install
 	$(INSTALL_DIR) $(1)/usr/bin/nemea
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/nemea/siot-wsn-anomaly $(1)/usr/bin/nemea/
 endef
@@ -126,4 +118,3 @@ $(eval $(call BuildPackage,siot-lora-airtime))
 $(eval $(call BuildPackage,siot-lora-distance))
 $(eval $(call BuildPackage,siot-lora-replay))
 $(eval $(call BuildPackage,siot-wsn-anomaly))
-


### PR DESCRIPTION
In this PR, there are several changes.

Before this in `make menuconfig`, there were 3 sections.
- NEMEA-SIoT
- NEMEA
- CESNET

Let's have just one. Don't make it more confusing. It means to be simpler and understandable.
There is no need to have own section for each thing. Packages always belong to some section, if you want to have yours inside Utils or somewhere, then it's fine.

Also, in `make menuconfig`, there were some packages with too long title, so it was not correctly displayed. 
![Screenshot from 2019-09-15 16-20-50](https://user-images.githubusercontent.com/4096468/65038092-716b1e00-d94f-11e9-88eb-9e5f9b45cd28.png)

With all of these changes, it looks like this:
![Screenshot from 2019-09-17 09-24-16](https://user-images.githubusercontent.com/4096468/65038172-aaa38e00-d94f-11e9-9515-da8c6db0403a.png)

I was thinking that I will change the names of those packages from siot to nemea as it was introduced recently, but it is your decision. 

nemea-siot with poco-all are compile tested. Beeeon-gateway I can not compile with or without my changes. If you need poco-all, I know that it is simpler to have it in fork feeds, but if you need to have full variant of poco, let's ask with an issue in OpenWrt packages or send it to them, they will appreciate it. As an example, beeeon-gateway Makefile deserves a lot of improvements. Install section doesn't look good.

When I was at it, I noticed that there in some sections there have an incorrect indentation and as well the license. Details are also included in commit messages.

Fixes: #9
Also, it's good that packages are not so often renamed. It should stick to the same name otherwise we or you will need to help users, why the update won't proceed as the requested package is no longer available.