### PR TITLE
ipfixprobe: update to version 3.2.0 and Makefile polishing

### DIFF
--- a/net/ipfixprobe/Makefile
+++ b/net/ipfixprobe/Makefile
@@ -1,36 +1,18 @@
-#
-# Copyright (C) 2006-2013 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
-
 PKG_NAME:=ipfixprobe
-PKG_REV:=7fbe77a
-
-PKG_VERSION:=3.2.0
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=ipfixprobe-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/CESNET/ipfixprobe
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_FIXUP:=autoreconf
-
-
-PKG_LICENSE:=GPLv2
-PKG_LICENSE_FILES:=COPYING
+PKG_SOURCE_URL:=https://github.com/CESNET/ipfixprobe.git
+PKG_SOURCE_DATE:=2021-07-28
+PKG_SOURCE_VERSION:=7fbe77aac01efc1f6cf9a99db08842c92034e385
+PKG_MIRROR_HASH:=aac0881ba8627897b23906eabde97450178a8f9285699c0368f88a745a934b96
 
 PKG_MAINTAINER:=Tomas Cejka <cejkat@cesnet.cz>
+PKG_LICENSE:=BSD-3-Clause
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -39,10 +21,14 @@ include $(INCLUDE_DIR)/package.mk
 define Package/ipfixprobe
   SECTION:=net
   CATEGORY:=Network
-  DEPENDS:=+libpcap +libstdcpp
   TITLE:=IPFIX flow exporter
   URL:=https://github.com/CESNET/ipfixprobe
-  MENU:=1
+  DEPENDS:=+libpcap +libstdcpp
+endef
+
+define Package/ipfixprobe/description
+  This NEMEA module creates biflows from input PCAP file / network interface
+  and exports them to output interface.
 endef
 
 define Package/ipfixprobe/config
@@ -58,10 +44,6 @@ CONFIGURE_ARGS += \
 	--enable-static \
 	--disable-silent-rules
 
-define Build/Configure
-	$(call Build/Configure/Default)
-endef
-
 define Package/ipfixprobe/install
 	$(INSTALL_DIR) $(1)/usr/bin/
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ipfixprobe $(1)/usr/bin/ipfixprobe
@@ -70,7 +52,7 @@ define Package/ipfixprobe/install
 	$(INSTALL_BIN) ./files/init.d/ipfixprobe $(1)/etc/init.d/
 
 	$(INSTALL_DIR) $(1)/etc/config
-	$(INSTALL_DATA) ./files/config/ipfixprobe $(1)/etc/config/
+	$(INSTALL_CONF) ./files/config/ipfixprobe $(1)/etc/config/
 endef
 
 $(eval $(call BuildPackage,ipfixprobe))

--- a/net/ipfixprobe/files/init.d/ipfixprobe
+++ b/net/ipfixprobe/files/init.d/ipfixprobe
@@ -19,7 +19,7 @@ STOP=50
 
 USE_PROCD=1
 
-CONFIG_FILE=ipfixprobe
+CONF_FILE=/etc/config/ipfixprobe
 BIN_FILE=/usr/bin/ipfixprobe
 
 . /lib/functions.sh
@@ -60,7 +60,7 @@ start_profile()
 
 start_service()
 {
-   config_load "$CONFIG_FILE"
+   config_load "$CONF_FILE"
 
    if [ $# -eq 0 ]; then
       # start all (enabled) profiles


### PR DESCRIPTION
- Removed OpenWrt license as we are not affiliated anyhow with OpenWrt.
More details: https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md#makefile-contents-should-contain

- These days PKG_REV is not commonly used in OpenWrt packages feed.
So, let's get rid of it. It was replaced by using PKG_SOURCE_DATE, PKG_SOURCE_VERSION
Also, it simplifies Makefile. There is also possibility to use tags or
releases, but in ipfixprobe, there are none. Be careful about PKG_MIRROR_HASH.
More details can be found here: https://openwrt.org/docs/guide-developer/packages

**In Turris packages, we are using tags:** https://gitlab.nic.cz/turris/turris-os-packages/-/blob/master/updater/updater-ng/Makefile#L16
Which is much better, but there is nothing wrong about **PKG_SOURCE_DATE, PKG_SOURCE_VERSION, PKG_MIRROR_HASH.**

- Value in variable PKG_BUILD_DIR is default.
This can be checked in file [include/package.mk](https://github.com/openwrt/packages/blob/master/CONTRIBUTING.md#makefile-contents-should-contain) from OpenWrt main
repository. Let's remove it from this Makefile.

- Corrected License as ipfixprobe is using BSD-3-Clause or GPL-2.0-or-later
by checking individual files.
I am using valid SPDX License Identifier.

- This is NEMEA module, so it should be listed under NEMEA submenu.

- Added description of this package.
This can be seen in make menuconfig
and on the router while using opkg info and/or opkg list

- Removed dummy MENU in make menuconfig caused by MENU=1
(screenshots can be found in mine pull request)

**How it looked before my changes:**
![Screenshot from 2020-11-06 16-02-06](https://user-images.githubusercontent.com/4096468/98383008-3abcff00-204c-11eb-8b10-ea0512876dd3.png)
![Screenshot from 2020-11-06 16-02-16](https://user-images.githubusercontent.com/4096468/98383013-3c86c280-204c-11eb-84a9-fadf232ac8d8.png)
![Screenshot from 2020-11-06 16-03-34](https://user-images.githubusercontent.com/4096468/98383167-6cce6100-204c-11eb-8a21-06b51d5c0228.png)


**And now it looks**
![Screenshot from 2020-11-06 16-03-30](https://user-images.githubusercontent.com/4096468/98383066-4dcfcf00-204c-11eb-9717-21ebbd38f025.png)

- Fixed order in conffile define
It means that config file is marked as configuration file and it won't be
overwritten by an update, which is now done by an incorrect order.

- Removed define Build/Configure as we are calling default.
It works without it.

- Changed permission of ipfixprobe config from 0644 to 0600

Compile and run tested on Turris Omnia, Turris OS 5.1.3 based on OpenWrt 19.07.4

Signed-off-by: Josef Schlehofer <pepe.schlehofer@gmail.com>