### PR TITLE
Split PyTrap to separate Makefile and update Nemea framework

### DIFF
--- a/lang/python/python-nemea-pytrap/Makefile
+++ b/lang/python/python-nemea-pytrap/Makefile
@@ -1,0 +1,34 @@
+include $(TOPDIR)/rules.mk
+
+PKG_NAME:=nemea-pytrap
+PKG_VERSION:=0.12.2
+PKG_RELEASE:=1
+
+PYPI_NAME:=$(PKG_NAME)
+PKG_HASH:=33388c81f12754e4288d630a18f0c136d5bac67b4bfc37a86aa82e2381f78cb5
+
+PKG_MAINTAINER:=Tomas Cejka <cejkat@cesnet.cz>
+PKG_LICENSE:=BSD-3-Clause
+
+include $(TOPDIR)/feeds/packages/lang/python/pypi.mk
+include $(INCLUDE_DIR)/package.mk
+include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
+
+define Package/python3-nemea-pytrap
+  SECTION:=net
+  CATEGORY:=Network
+  SUBMENU:=NEMEA
+  TITLE:=Python extension of the NEMEA project
+  URL:=https://github.com/CESNET/Nemea-Framework
+  DEPENDS:=+python3 +nemea-framework +libpthread
+  VARIANT:=python3
+endef
+
+define Package/python3-nemea-pytrap/description
+  The pytrap module is a native Python extension that
+  allows for writing NEMEA modules in Python.
+endef
+
+$(eval $(call Py3Package,python3-nemea-pytrap))
+$(eval $(call BuildPackage,python3-nemea-pytrap))
+$(eval $(call BuildPackage,python3-nemea-pytrap-src))

--- a/libs/nemea-framework/Makefile
+++ b/libs/nemea-framework/Makefile
@@ -1,41 +1,18 @@
-#
-# Copyright (C) 2006-2013 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
-ifndef include_mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-package.mk
-include $(TOPDIR)/feeds/packages/lang/python/python3-host.mk
-else
-$(call include_mk, python3-package.mk)
-$(call include_mk, python3-host.mk)
-endif
-
 PKG_NAME:=nemea-framework
-PKG_REV:=e4cf87e
-PKG_VERSION:=2.1.2
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=nemea-framework-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/CESNET/nemea-framework
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_FIXUP:=autoreconf
-
-PKG_LICENSE:=GPLv2
-PKG_LICENSE_FILES:=COPYING
+PKG_SOURCE_URL:=https://github.com/CESNET/nemea-framework.git
+PKG_SOURCE_DATE:=2021-07-29
+PKG_SOURCE_VERSION:=e4cf87e746015e37502508361831ab7209191437
+PKG_MIRROR_HASH:=4b259690d8a53ec3499e2183a025ffa873d2ab93bc76a034c4c4a8d8c2e21785
 
 PKG_MAINTAINER:=Tomas Cejka <cejkat@cesnet.cz>
+PKG_LICENSE:=BSD-3-Clause
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -48,21 +25,36 @@ define Package/nemea-framework
   DEPENDS:=+libpthread +librt +libstdcpp +libopenssl
   TITLE:=NEMEA system libraries
   URL:=https://github.com/CESNET/nemea-framework
-  MENU:=1
 endef
 
 define Package/nemea-framework/description
-This package contains a system-independent library for the Nemea system - system for network traffic analysis and anomaly detection.
+  This package contains a system-independent library for the Nemea.
+  It is system for network traffic analysis and anomaly detection.
 endef
 
 define Package/nemea-framework/config
 	source "$(SOURCE)/Config.in"
 endef
 
+TARGET_CFLAGS += \
+	-ffunction-sections \
+	-fdata-sections
+
+CONFIGURE_VARS += \
+	ac_cv_linux_vers=$(LINUX_VERSION) \
+	ac_cv_header_libusb_1_0_libusb_h=no \
+	ac_cv_netfilter_can_compile=no
+
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
-	--disable-python --disable-pycommon --disable-silent-rules --disable-example --disable-tests LIBS=-lm --bindir=\$$(bindir)/nemea \
+	--disable-python \
+	--disable-pycommon \
+	--disable-silent-rules \
+	--disable-example \
+	--disable-tests \
+	LIBS=-lm \
+	--bindir=\$$(bindir)/nemea \
 	--with-build-cc="$(HOSTCC)" \
 	--with-ifcbuffersize=$(CONFIG_NEMEA_LIBTRAP_BUFFER_SIZE) \
 	--with-ifcmaxclients=$(CONFIG_NEMEA_LIBTRAP_IFC_MAX_CLIENTS) \
@@ -71,9 +63,6 @@ CONFIGURE_ARGS += \
 MAKE_FLAGS += \
 	CCOPT="$(TARGET_CFLAGS) -I$(BUILD_DIR)/linux/include"
 
-define Build/Configure
-	$(call Build/Configure/Default)
-endef
 define Build/InstallDev
 	$(INSTALL_DIR) $(2)/bin
 	$(CP) $(PKG_BUILD_DIR)/unirec/ur_processor.sh $(2)/bin/
@@ -100,40 +89,4 @@ define Package/nemea-framework/install
 	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/nemea/trap_stats $(1)/usr/bin/nemea/
 endef
 
-define Package/nemea-pytrap
-  $(call Package/nemea-framework)
-  TITLE:=NEMEA pytrap
-  DEPENDS:=+python3 +nemea-framework +libpthread
-endef
-
-define Package/nemea-pytrap/description
-Python API of libtrap and UniRec
-endef
-
-define Package/nemea-pytrap/install
-	cd $(PKG_BUILD_DIR)/pytrap; \
-	$(HOST_PYTHON3_BIN) ./setup.py install --prefix="/usr" --root=$(1)
-endef
-
-define BuildPytrap
-	cd $(PKG_BUILD_DIR)/pytrap; \
-	CC="$(TARGET_CC)" \
-	CCSHARED="$(TARGET_CC) $(FPIC)" \
-	CXX="$(TARGET_CXX)" \
-	LD="$(TARGET_CC)" \
-	LDFLAGS="$(TARGET_LDFLAGS) -L$(PKG_BUILD_DIR)/libtrap/src/.libs/ -L$(PKG_BUILD_DIR)/unirec/.libs/" \
-	LDSHARED="$(TARGET_CC) -shared" \
-	CFLAGS="$(TARGET_CFLAGS)" \
-	CPPFLAGS="$(TARGET_CPPFLAGS) -I$(PYTHON3_INC_DIR) -I$(PKG_BUILD_DIR)/libtrap/include/ -I$(PKG_BUILD_DIR)" \
-	$(HOST_PYTHON3_BIN) ./setup.py build
-endef
-
-define Build/Compile
-	$(call Build/Compile/Default)
-	$(call BuildPytrap)
-endef
-
-$(eval $(call BuildPackage,nemea-framework,+libpthread,+librt))
-
-$(eval $(call BuildPackage,nemea-pytrap,+libpthread,+libc))
-
+$(eval $(call BuildPackage,nemea-framework))


### PR DESCRIPTION
**Framework:**

While at it, I did Makefile polishing
- Dropped OpenWrt copyright as we are not working under contract to
OpenWrt
- We are now using latest Git hash commit.
(Dropped duplicated things, which are default)
- Dropped dummy MENU
- Dropped std=gnu99 as it is not needed with GCC7 and newer
- Changed License to correct one according to SPDX License Identifiers

Compile tested on Turris Omnia, Turris OS 5.1.3 running on top of OpenWrt 19.07.4

**PyTrap:**

Compile tested on Turris Omnia, Turris OS 5.1.3 running on top of OpenWrt 19.07.4. 
While importing I have this issue:
```
>>> import pytrap
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
ImportError: Error relocating /usr/lib/python3.7/site-packages/pytrap.cpython-37.so: ip_is_null: symbol not found
```
But I get this same error while using package nemea-pytrap from your repository.


This is draft until I would be able to run test it sucessfully.

