### PR TITLE
nemea-modules: Makefile polishing

### DIFF
--- a/net/nemea-modules/Makefile
+++ b/net/nemea-modules/Makefile
@@ -1,35 +1,18 @@
-#
-# Copyright (C) 2006-2013 OpenWrt.org
-#
-# This is free software, licensed under the GNU General Public License v2.
-# See /LICENSE for more information.
-#
-
 include $(TOPDIR)/rules.mk
 
-
 PKG_NAME:=nemea-modules
-PKG_REV:=baddf92
-PKG_VERSION:=21-07.29
 PKG_RELEASE:=1
 
 PKG_SOURCE_PROTO:=git
-PKG_SOURCE_VERSION:=$(PKG_REV)
-PKG_SOURCE_SUBDIR:=nemea-modules-$(PKG_VERSION)
-PKG_SOURCE_URL:=https://github.com/CESNET/nemea-modules
-PKG_SOURCE:=$(PKG_NAME)-$(PKG_VERSION)-$(PKG_REV).tar.gz
-PKG_SOURCE_SUBDIR:=$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_BUILD_DIR:=$(BUILD_DIR)/$(PKG_NAME)-$(PKG_VERSION)
-
-PKG_FIXUP:=autoreconf
-
-
-PKG_LICENSE:=GPLv2
-PKG_LICENSE_FILES:=COPYING
+PKG_SOURCE_URL:=https://github.com/CESNET/nemea-modules.git
+PKG_SOURCE_DATE:=2021-07-29
+PKG_SOURCE_VERSION:=baddf9238cc85819282c1e055b183bd5d7745d08
+PKG_MIRROR_HASH:=6f726876fb4bf5ae32536b9951a6d7115300c68201027f7122dd376c7453d26f
 
 PKG_MAINTAINER:=Tomas Cejka <cejkat@cesnet.cz>
+PKG_LICENSE:=BSD-3-Clause
 
+PKG_FIXUP:=autoreconf
 PKG_INSTALL:=1
 PKG_BUILD_PARALLEL:=1
 
@@ -42,50 +25,65 @@ define Package/nemea-modules/Default
   DEPENDS:=+nemea-framework +libpthread +librt
   TITLE:=NEMEA module
   URL:=https://github.com/CESNET/nemea-modules
-  MENU:=1
 endef
 
 define Package/nemea-logreplay
 	$(call Package/nemea-modules/Default)
 	TITLE+=logreplay
-	DEPENDS+= +libstdcpp
+	DEPENDS+=+libstdcpp
 endef
+
 define Package/nemea-flowcounter
 	$(call Package/nemea-modules/Default)
 	TITLE+=flowcounter
 endef
+
 define Package/nemea-traffic_repeater
 	$(call Package/nemea-modules/Default)
 	TITLE+=traffic_repeater
 endef
+
 define Package/nemea-topn
 	$(call Package/nemea-modules/Default)
 	TITLE+=topn
 endef
+
 define Package/nemea-logger
 	$(call Package/nemea-modules/Default)
 	TITLE+=logger
 endef
+
 define Package/nemea-merger
 	$(call Package/nemea-modules/Default)
 	TITLE+=merger
 endef
+
 define Package/nemea-email_reporter
 	$(call Package/nemea-modules/Default)
 	TITLE+=email_reporter
-	DEPENDS+=+python3 +nemea-pytrap
+	DEPENDS+=+python3 +python3-nemea-pytrap
 endef
+
 define Package/nemea-supervisorl
 	$(call Package/nemea-modules/Default)
 	TITLE+=supervisorl
-	DEPENDS=
 endef
+
+TARGET_CFLAGS += \
+	-ffunction-sections \
+	-fdata-sections
+
+CONFIGURE_VARS += \
+	ac_cv_linux_vers=$(LINUX_VERSION) \
+	ac_cv_header_libusb_1_0_libusb_h=no \
+	ac_cv_netfilter_can_compile=no
 
 CONFIGURE_ARGS += \
 	--enable-shared \
 	--enable-static \
 	LIBS=-lm --bindir=/usr/bin/nemea --disable-silent-rules \
-	--with-build-cc="$(HOSTCC)"
+	--with-build-cc="$(HOSTCC)" \
+	--with-flowcachesize=$(CONFIG_NEMEA_FLOW_CACHE_SIZE)
 
 MAKE_FLAGS += \
 	CCOPT="$(TARGET_CFLAGS) -I$(BUILD_DIR)/linux/include"
@@ -126,7 +124,7 @@ define Package/nemea-supervisorl/install
 	$(INSTALL_DIR) $(1)/etc/init.d/
 	$(INSTALL_DIR) $(1)/etc/config/
 	$(INSTALL_BIN) ./files/init.d/nemea-supervisorl $(1)/etc/init.d/
-	$(INSTALL_DATA) ./files/config/nemea-supervisor $(1)/etc/config/nemea-supervisor
+	$(INSTALL_CONF) ./files/config/nemea-supervisor $(1)/etc/config/nemea-supervisor
 endef
 
 define Package/nemea-supervisorl/conffiles


### PR DESCRIPTION
Nemea modules:
- Drop variable PKG_REV, which is not used these days much.
Let's rather use PKG_SOURCE_DATE and drop variables like
PKG_SOURCE_SUBDIR, PKG_BUILD_DIR which have default values.

- Fix order in conffile define
By incorrect order it is not being applied, so
configuration file /etc/config/nemea-supervisor in package
nemea-supervisorl. Also, change chmod from 0644 to 0600.

- Rename dependency in nemea-email_reported regarding pytrap
from nemea-pytrap to python3-nemea-pytrap

This depends on https://github.com/CESNET/Nemea-OpenWRT/pull/18.