### PR TITLE
nemea-modules: fix path of ipfixprobe in nemea-supervisor cfg

### DIFF
--- a/net/ipfixprobe/Makefile
+++ b/net/ipfixprobe/Makefile
@@ -12,7 +12,7 @@ PKG_NAME:=ipfixprobe
 PKG_REV:=7fbe77a
 
 PKG_VERSION:=3.2.0
-PKG_RELEASE:=1
+PKG_RELEASE:=2
 
 PKG_SOURCE_PROTO:=git
 PKG_SOURCE_VERSION:=$(PKG_REV)
@@ -63,8 +63,8 @@ define Build/Configure
 endef
 
 define Package/ipfixprobe/install
-	$(INSTALL_DIR) $(1)/usr/bin/
-	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ipfixprobe $(1)/usr/bin/ipfixprobe
+	$(INSTALL_DIR) $(1)/usr/bin/nemea
+	$(INSTALL_BIN) $(PKG_INSTALL_DIR)/usr/bin/ipfixprobe $(1)/usr/bin/nemea/ipfixprobe
 
 	$(INSTALL_DIR) $(1)/etc/init.d
 	$(INSTALL_BIN) ./files/init.d/ipfixprobe $(1)/etc/init.d/


### PR DESCRIPTION
Ipfixprobe binary is installed to [/usr/bin/ipfixprobe](https://github.com/CESNET/Nemea-OpenWRT/blob/master/net/ipfixprobe/Makefile#L68).
In config, it looks for /usr/bin/nemea/ipfixprobe.