### PR TITLE
GitHub actions: drop Python 2 for Turris and update Turris OS

### DIFF
--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -16,7 +16,7 @@ jobs:
     # Checks-out your repository under $GITHUB_WORKSPACE, so your job can access it
     - uses: actions/checkout@v2
     - name: Install dependencies
-      run: sudo apt-get update; sudo apt-get -y install build-essential git ncurses-dev python2
+      run: sudo apt-get update; sudo apt-get -y install build-essential git ncurses-dev
     - name: Run a one-line script
       run: git clone -b v6.2.0 --depth 1 'https://gitlab.nic.cz/turris/turris-build' "$GITHUB_WORKSPACE"/../turris-build
     - name: Update feeds.conf for local repo

--- a/.github/workflows/packages.yml
+++ b/.github/workflows/packages.yml
@@ -18,7 +18,7 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get update; sudo apt-get -y install build-essential git ncurses-dev
     - name: Run a one-line script
-      run: git clone -b v6.2.0 --depth 1 'https://gitlab.nic.cz/turris/turris-build' "$GITHUB_WORKSPACE"/../turris-build
+      run: git clone -b v6.2.4 --depth 1 'https://gitlab.nic.cz/turris/turris-build' "$GITHUB_WORKSPACE"/../turris-build
     - name: Update feeds.conf for local repo
       run: cd "$GITHUB_WORKSPACE"/../turris-build; sed -i "s|^src-git cesnet.*|src-git cesnet $GITHUB_WORKSPACE|" feeds.conf
     - name: Prepare build for Turris MOX


### PR DESCRIPTION
In https://github.com/CESNET/Nemea-OpenWRT/pull/39 , there was added Python 2 dependency, which was wrong as anyone these days should use active Python 3.x releases as Python 2 support is EoL.